### PR TITLE
Add generate endpoint that forwards prompts to chosen model

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/go-chi/chi/v5 v5.0.8
 	github.com/prometheus/client_golang v1.17.0
+	github.com/sashabaranov/go-openai v1.15.4
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/prometheus/common v0.44.0/go.mod h1:ofAIvZbQ1e/nugmZGz4/qCb9Ap1VoSTIO
 github.com/prometheus/procfs v0.11.1 h1:xRC8Iq1yyca5ypa9n1EZnWZkt7dwcoRPQwX/5gwaUuI=
 github.com/prometheus/procfs v0.11.1/go.mod h1:eesXgaPo1q7lBpVMoMy0ZOFTth9hBn4W/y0/p/ScXhY=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
+github.com/sashabaranov/go-openai v1.15.4 h1:BXCR0Uxk5RipeY4yBC7g6pBVfcjh8jwrMNOYdie6yuk=
+github.com/sashabaranov/go-openai v1.15.4/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.11.0 h1:eG7RXZHdqOJ1i+0lgLgCpSXAp6M3LYlAo6osgSi0xOM=
 golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/inference/inference.go
+++ b/internal/inference/inference.go
@@ -1,0 +1,43 @@
+package inference
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+
+	openai "github.com/sashabaranov/go-openai"
+)
+
+// SendPrompt sends the given prompt to the specified model and returns the model's
+// response. Currently only OpenAI GPT models are supported. The OpenAI API key
+// must be provided via the OPENAI_API_KEY environment variable.
+func SendPrompt(modelID, prompt string) (string, error) {
+	if strings.HasPrefix(modelID, "gpt-") {
+		apiKey := os.Getenv("OPENAI_API_KEY")
+		if apiKey == "" {
+			return "", errors.New("OPENAI_API_KEY not set")
+		}
+		client := openai.NewClient(apiKey)
+		resp, err := client.CreateChatCompletion(
+			context.Background(),
+			openai.ChatCompletionRequest{
+				Model: modelID,
+				Messages: []openai.ChatCompletionMessage{
+					{
+						Role:    openai.ChatMessageRoleUser,
+						Content: prompt,
+					},
+				},
+			},
+		)
+		if err != nil {
+			return "", err
+		}
+		if len(resp.Choices) == 0 {
+			return "", errors.New("empty response from model")
+		}
+		return resp.Choices[0].Message.Content, nil
+	}
+	return "", errors.New("unsupported model: " + modelID)
+}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -1,70 +1,114 @@
 package server
 
 import (
-    "encoding/json"
-    "log"
-    "net/http"
+	"encoding/json"
+	"log"
+	"net/http"
 
-    "llm-router-go/internal/config"
-    "llm-router-go/internal/selection"
-    "llm-router-go/internal/types"
+	"llm-router-go/internal/config"
+	"llm-router-go/internal/inference"
+	"llm-router-go/internal/selection"
+	"llm-router-go/internal/types"
 )
 
 // SelectRequest represents the JSON payload for selecting a model.
 type SelectRequest struct {
-    Prompt      string                 `json:"prompt"`
-    Context     *types.Context         `json:"context"`
-    Preferences map[string]interface{} `json:"preferences"`
+	Prompt      string                 `json:"prompt"`
+	Context     *types.Context         `json:"context"`
+	Preferences map[string]interface{} `json:"preferences"`
 }
 
 // SelectHandler returns an http.HandlerFunc that selects a model using the
 // provided ConfigStore.  The handler reads the JSON payload, invokes the
 // selection logic and writes the response as JSON.
 func SelectHandler(store *config.ConfigStore) http.HandlerFunc {
-    return func(w http.ResponseWriter, r *http.Request) {
-        // Decode request
-        var req SelectRequest
-        dec := json.NewDecoder(r.Body)
-        dec.DisallowUnknownFields()
-        if err := dec.Decode(&req); err != nil {
-            http.Error(w, "invalid JSON payload", http.StatusBadRequest)
-            return
-        }
-        if req.Prompt == "" {
-            http.Error(w, "prompt is required", http.StatusBadRequest)
-            return
-        }
-        models := store.GetModels()
-        result, err := selection.SelectModel(req.Prompt, req.Context, models, req.Preferences)
-        if err != nil {
-            http.Error(w, err.Error(), http.StatusBadRequest)
-            return
-        }
-        w.Header().Set("Content-Type", "application/json")
-        enc := json.NewEncoder(w)
-        enc.SetIndent("", "  ")
-        if err := enc.Encode(result); err != nil {
-            log.Printf("failed to write response: %v", err)
-        }
-    }
+	return func(w http.ResponseWriter, r *http.Request) {
+		// Decode request
+		var req SelectRequest
+		dec := json.NewDecoder(r.Body)
+		dec.DisallowUnknownFields()
+		if err := dec.Decode(&req); err != nil {
+			http.Error(w, "invalid JSON payload", http.StatusBadRequest)
+			return
+		}
+		if req.Prompt == "" {
+			http.Error(w, "prompt is required", http.StatusBadRequest)
+			return
+		}
+		models := store.GetModels()
+		result, err := selection.SelectModel(req.Prompt, req.Context, models, req.Preferences)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(result); err != nil {
+			log.Printf("failed to write response: %v", err)
+		}
+	}
+}
+
+// GenerateResponse contains both the selected model details and the model's
+// output text.
+type GenerateResponse struct {
+	Model  selection.Result `json:"model"`
+	Output string           `json:"output"`
+}
+
+// GenerateHandler selects the best model for the given prompt and then forwards
+// the prompt to that model, returning the model's output.
+func GenerateHandler(store *config.ConfigStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req SelectRequest
+		dec := json.NewDecoder(r.Body)
+		dec.DisallowUnknownFields()
+		if err := dec.Decode(&req); err != nil {
+			http.Error(w, "invalid JSON payload", http.StatusBadRequest)
+			return
+		}
+		if req.Prompt == "" {
+			http.Error(w, "prompt is required", http.StatusBadRequest)
+			return
+		}
+		models := store.GetModels()
+		result, err := selection.SelectModel(req.Prompt, req.Context, models, req.Preferences)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		output, err := inference.SendPrompt(result.RecommendedModel, req.Prompt)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadGateway)
+			return
+		}
+		resp := GenerateResponse{Model: result, Output: output}
+		w.Header().Set("Content-Type", "application/json")
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(resp); err != nil {
+			log.Printf("failed to write response: %v", err)
+		}
+	}
 }
 
 // ModelsHandler writes the current models registry as JSON.
 func ModelsHandler(store *config.ConfigStore) http.HandlerFunc {
-    return func(w http.ResponseWriter, r *http.Request) {
-        models := store.GetModels()
-        w.Header().Set("Content-Type", "application/json")
-        enc := json.NewEncoder(w)
-        enc.SetIndent("", "  ")
-        if err := enc.Encode(models); err != nil {
-            log.Printf("failed to write models response: %v", err)
-        }
-    }
+	return func(w http.ResponseWriter, r *http.Request) {
+		models := store.GetModels()
+		w.Header().Set("Content-Type", "application/json")
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(models); err != nil {
+			log.Printf("failed to write models response: %v", err)
+		}
+	}
 }
 
 // HealthHandler is a simple liveness check.
 func HealthHandler(w http.ResponseWriter, r *http.Request) {
-    w.Header().Set("Content-Type", "text/plain")
-    w.WriteHeader(http.StatusOK)
-    _, _ = w.Write([]byte("ok"))
+	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ok"))
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,25 +1,27 @@
 package server
 
 import (
-    "net/http"
+	"net/http"
 
-    "github.com/go-chi/chi/v5"
-    "github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/go-chi/chi/v5"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 
-    "llm-router-go/internal/config"
+	"llm-router-go/internal/config"
 )
 
 // NewRouter constructs a chi Router with all API routes registered.  It
 // requires a ConfigStore containing the loaded models.
 func NewRouter(store *config.ConfigStore) http.Handler {
-    r := chi.NewRouter()
-    // Health check
-    r.Get("/v1/health", HealthHandler)
-    // Model registry
-    r.Get("/v1/models", ModelsHandler(store))
-    // Selection endpoint
-    r.Post("/v1/select-model", SelectHandler(store))
-    // Prometheus metrics
-    r.Handle("/metrics", promhttp.Handler())
-    return r
+	r := chi.NewRouter()
+	// Health check
+	r.Get("/v1/health", HealthHandler)
+	// Model registry
+	r.Get("/v1/models", ModelsHandler(store))
+	// Selection endpoint
+	r.Post("/v1/select-model", SelectHandler(store))
+	// Generate endpoint - selects a model and forwards the prompt
+	r.Post("/v1/generate", GenerateHandler(store))
+	// Prometheus metrics
+	r.Handle("/metrics", promhttp.Handler())
+	return r
 }


### PR DESCRIPTION
## Summary
- add `GenerateHandler` to pick best model and forward prompt
- expose new `/v1/generate` endpoint
- implement `inference` package using OpenAI API

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689a29cd4b94832fbb4fec4806e11999