### PR TITLE
feat(api): add /v1/recommend + OpenAPI + catalog scoring for Copilot Extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# llm-router-go
+
+This service recommends suitable language models for a given prompt and context.
+
+## Copilot Extension Integration
+
+- Endpoint: `POST /v1/recommend`
+- OpenAPI: `api/openapi.yaml`
+- Auth: header `X-API-Key` (set `ROUTER_API_KEY`)
+- **Note:** Calls made from Copilot Chat consume a Copilot request (billing by GitHub).
+- No public API to auto-switch Copilot’s model; we return the recommendation for the client UI to guide the user.
+

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,0 +1,95 @@
+openapi: 3.0.1
+info:
+  title: llm-router
+  version: 1.0.0
+servers:
+  - url: https://YOUR_HOST
+paths:
+  /v1/recommend:
+    post:
+      summary: Recommend the best model for a given prompt/context
+      operationId: recommend
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RecommendRequest'
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecommendResponse'
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key
+  schemas:
+    RecommendRequest:
+      type: object
+      required: [prompt]
+      properties:
+        prompt: { type: string }
+        context:
+          $ref: '#/components/schemas/Context'
+        catalog:
+          type: array
+          items: { type: string }
+        limits:
+          type: object
+          properties:
+            max_prompt_kb: { type: integer }
+        meta:
+          type: object
+          additionalProperties: true
+    Context:
+      type: object
+      properties:
+        language: { type: string }
+        file_path: { type: string }
+        selection_bytes: { type: integer }
+        repo:
+          type: object
+          properties:
+            name: { type: string }
+            visibility: { type: string, enum: [public, private] }
+            monorepo: { type: boolean }
+            loc_estimate: { type: integer }
+        signals:
+          type: object
+          additionalProperties: { type: string }
+        snippets:
+          type: array
+          items:
+            type: object
+            required: [source]
+            properties:
+              source: { type: string, enum: [selection,file,open_editors,clipboard,repo] }
+              path: { type: string }
+              text: { type: string }
+              truncated: { type: boolean }
+              bytes: { type: integer }
+    RecommendResponse:
+      type: object
+      required: [recommended_model, version]
+      properties:
+        recommended_model: { type: string }
+        rationale: { type: string }
+        confidence: { type: number }
+        alternatives:
+          type: array
+          items: { type: string }
+        cost_ms_estimate: { type: integer }
+        tokens_in_estimate: { type: integer }
+        tokens_out_estimate: { type: integer }
+        flags:
+          type: array
+          items: { type: string }
+        trace_id: { type: string }
+        version: { type: string }

--- a/config/models.yaml
+++ b/config/models.yaml
@@ -1,48 +1,25 @@
 models:
-  - id: gpt-3.5-turbo
-    name: GPT-3.5 Turbo
-    capabilities:
-      code: 0.65
-      text: 0.80
-      analysis: 0.70
-    cost_input: 0.0005
-    cost_output: 0.0005
-    context_window: 4096
-    latency_ms: 300
-    tags: [budget, general]
-
-  - id: gpt-4-turbo
-    name: GPT-4 Turbo
-    capabilities:
-      code: 0.90
-      text: 0.92
-      analysis: 0.85
-    cost_input: 0.003
-    cost_output: 0.006
-    context_window: 128000
-    latency_ms: 600
-    tags: [premium, high-quality, large-context]
-
-  - id: claude-3-opus
-    name: Claude 3 Opus
-    capabilities:
-      code: 0.88
-      text: 0.93
-      analysis: 0.87
-    cost_input: 0.008
-    cost_output: 0.024
-    context_window: 200000
-    latency_ms: 800
-    tags: [premium, high-quality]
-
-  - id: codellama-70b
-    name: Code Llama 70B (local)
-    capabilities:
-      code: 0.70
-      text: 0.50
-      analysis: 0.40
-    cost_input: 0.0001
-    cost_output: 0.0001
-    context_window: 4096
-    latency_ms: 150
-    tags: [open-source, budget, code]
+  - name: gpt-4o
+    strengths: [reasoning, code-gen]
+    max_input_tokens: 128000
+    cost_tier: high
+    latency_tier: med
+    languages: [ts, js, py, go, java, cpp, md]
+  - name: gpt-4o-mini
+    strengths: [code-gen, fast]
+    max_input_tokens: 64000
+    cost_tier: med
+    latency_tier: low
+    languages: [ts, js, py, go, md]
+  - name: claude-3.5-sonnet
+    strengths: [reasoning, long-context]
+    max_input_tokens: 200000
+    cost_tier: high
+    latency_tier: med
+    languages: [py, ts, go, java, md]
+  - name: gemini-1.5-pro
+    strengths: [multimodal, long-context]
+    max_input_tokens: 1000000
+    cost_tier: high
+    latency_tier: med
+    languages: [md, py, js, go]

--- a/examples/copilot.http
+++ b/examples/copilot.http
@@ -1,0 +1,16 @@
+### Recommend (minimal)
+POST http://localhost:8080/v1/recommend
+Content-Type: application/json
+X-API-Key: dev
+
+{
+  "prompt": "Summarize this function and suggest a model",
+  "context": {
+    "language": "go",
+    "file_path": "internal/http/handlers/recommend.go",
+    "selection_bytes": 2048,
+    "snippets": [
+      {"source":"selection","text":"func foo() {}", "bytes": 14}
+    ]
+  }
+}

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -1,0 +1,50 @@
+package api
+
+type RecommendRequest struct {
+	Prompt  string         `json:"prompt"`
+	Context *Context       `json:"context,omitempty"`
+	Catalog []string       `json:"catalog,omitempty"`
+	Limits  *Limits        `json:"limits,omitempty"`
+	Meta    map[string]any `json:"meta,omitempty"`
+}
+
+type Context struct {
+	Language       string            `json:"language,omitempty"`
+	FilePath       string            `json:"file_path,omitempty"`
+	SelectionBytes int               `json:"selection_bytes,omitempty"`
+	Repo           *RepoInfo         `json:"repo,omitempty"`
+	Signals        map[string]string `json:"signals,omitempty"`
+	Snippets       []ContextSnippet  `json:"snippets,omitempty"`
+}
+
+type ContextSnippet struct {
+	Source    string `json:"source"`
+	Path      string `json:"path,omitempty"`
+	Text      string `json:"text,omitempty"`
+	Truncated bool   `json:"truncated,omitempty"`
+	Bytes     int    `json:"bytes,omitempty"`
+}
+
+type RepoInfo struct {
+	Name        string `json:"name,omitempty"`
+	Visibility  string `json:"visibility,omitempty"`
+	Monorepo    bool   `json:"monorepo,omitempty"`
+	LocEstimate int    `json:"loc_estimate,omitempty"`
+}
+
+type Limits struct {
+	MaxPromptKB int `json:"max_prompt_kb,omitempty"`
+}
+
+type RecommendResponse struct {
+	RecommendedModel  string   `json:"recommended_model"`
+	Rationale         string   `json:"rationale,omitempty"`
+	Confidence        float32  `json:"confidence,omitempty"`
+	Alternatives      []string `json:"alternatives,omitempty"`
+	CostMsEstimate    int      `json:"cost_ms_estimate,omitempty"`
+	TokensInEstimate  int      `json:"tokens_in_estimate,omitempty"`
+	TokensOutEstimate int      `json:"tokens_out_estimate,omitempty"`
+	Flags             []string `json:"flags,omitempty"`
+	TraceID           string   `json:"trace_id,omitempty"`
+	Version           string   `json:"version"`
+}

--- a/internal/api/validate.go
+++ b/internal/api/validate.go
@@ -1,0 +1,13 @@
+package api
+
+import "errors"
+
+func (r *RecommendRequest) Validate() error {
+	if r.Prompt == "" {
+		return errors.New("prompt is required")
+	}
+	if r.Limits != nil && r.Limits.MaxPromptKB < 0 {
+		return errors.New("limits.max_prompt_kb must be >= 0")
+	}
+	return nil
+}

--- a/internal/http/handlers/recommend.go
+++ b/internal/http/handlers/recommend.go
@@ -1,0 +1,47 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"llm-router-go/internal/api"
+	"llm-router-go/internal/policy"
+)
+
+type RecommendDeps struct {
+	Version string
+	Catalog policy.Catalog
+	APIKey  string
+}
+
+func Recommend(d RecommendDeps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		if d.APIKey != "" && r.Header.Get("X-API-Key") != d.APIKey {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		var req api.RecommendRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "bad json: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		if err := req.Validate(); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		dec := policy.Score(d.Catalog, &req)
+		res := api.RecommendResponse{
+			RecommendedModel: dec.Top,
+			Rationale:        dec.Rationale,
+			Confidence:       dec.Confidence,
+			Alternatives:     dec.Alternatives,
+			CostMsEstimate:   int(time.Since(start).Milliseconds()),
+			Flags:            dec.Flags,
+			Version:          d.Version,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(res)
+	}
+}

--- a/internal/http/handlers/recommend_test.go
+++ b/internal/http/handlers/recommend_test.go
@@ -1,0 +1,42 @@
+package handlers_test
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"llm-router-go/internal/http/handlers"
+	"llm-router-go/internal/policy"
+)
+
+func TestRecommend_OK(t *testing.T) {
+	cat := policy.Catalog{Models: []policy.Model{{Name: "gpt-4o"}, {Name: "gpt-4o-mini"}}}
+	h := handlers.Recommend(handlers.RecommendDeps{Version: "test", Catalog: cat})
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	body := []byte(`{"prompt":"explain this","context":{"language":"go","selection_bytes":1024}}`)
+	req, _ := http.NewRequest("POST", srv.URL, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.StatusCode != 200 {
+		t.Fatalf("status=%d", res.StatusCode)
+	}
+}
+
+func TestRecommend_Auth(t *testing.T) {
+	cat := policy.Catalog{Models: []policy.Model{{Name: "gpt-4o"}}}
+	h := handlers.Recommend(handlers.RecommendDeps{Version: "test", Catalog: cat, APIKey: "dev"})
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	req, _ := http.NewRequest("POST", srv.URL, bytes.NewReader([]byte(`{"prompt":"x"}`)))
+	req.Header.Set("Content-Type", "application/json")
+	if res, _ := http.DefaultClient.Do(req); res.StatusCode != 401 {
+		t.Fatalf("expected 401, got %d", res.StatusCode)
+	}
+}

--- a/internal/policy/catalog.go
+++ b/internal/policy/catalog.go
@@ -1,0 +1,28 @@
+package policy
+
+import (
+	"gopkg.in/yaml.v3"
+	"os"
+)
+
+type Model struct {
+	Name           string   `yaml:"name"`
+	Strengths      []string `yaml:"strengths"`
+	MaxInputTokens int      `yaml:"max_input_tokens"`
+	CostTier       string   `yaml:"cost_tier"`
+	LatencyTier    string   `yaml:"latency_tier"`
+	Languages      []string `yaml:"languages"`
+}
+
+type Catalog struct {
+	Models []Model `yaml:"models"`
+}
+
+func LoadCatalog(path string) (Catalog, error) {
+	var c Catalog
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return c, err
+	}
+	return c, yaml.Unmarshal(b, &c)
+}

--- a/internal/policy/score.go
+++ b/internal/policy/score.go
@@ -1,0 +1,98 @@
+package policy
+
+import (
+	"llm-router-go/internal/api"
+	"strings"
+)
+
+type Decision struct {
+	Top          string
+	Alternatives []string
+	Confidence   float32
+	Rationale    string
+	Flags        []string
+}
+
+func Score(c Catalog, req *api.RecommendRequest) Decision {
+	long := req.Context != nil && (req.Context.SelectionBytes > 48000 || sumBytes(req) > 120000)
+	lang := ""
+	if req.Context != nil {
+		lang = req.Context.Language
+	}
+
+	limit := map[string]bool{}
+	if len(req.Catalog) > 0 {
+		for _, m := range req.Catalog {
+			limit[m] = true
+		}
+	}
+
+	cands := []string{}
+	for _, m := range c.Models {
+		if len(limit) > 0 && !limit[m.Name] {
+			continue
+		}
+		if lang != "" && !contains(m.Languages, lang) {
+			continue
+		}
+		cands = append(cands, m.Name)
+	}
+	if len(cands) == 0 {
+		for _, m := range c.Models {
+			cands = append(cands, m.Name)
+		}
+	}
+
+	var top string
+	var conf float32 = 0.6
+	var why []string
+	flags := []string{}
+
+	if long {
+		for _, n := range []string{"claude-3.5-sonnet", "gemini-1.5-pro", "gpt-4o"} {
+			if has(cands, n) {
+				top = n
+				break
+			}
+		}
+		why = append(why, "Detected large context; prefer long-context models.")
+		flags = append(flags, "large_context")
+		conf = 0.72
+	} else {
+		for _, n := range []string{"gpt-4o-mini", "gpt-4o", "claude-3.5-sonnet"} {
+			if has(cands, n) {
+				top = n
+				break
+			}
+		}
+		why = append(why, "Moderate prompt; prefer fast code-generation.")
+	}
+
+	alts := []string{}
+	for _, n := range cands {
+		if n != top {
+			alts = append(alts, n)
+		}
+	}
+	return Decision{Top: top, Alternatives: alts, Confidence: conf, Rationale: strings.Join(why, " "), Flags: flags}
+}
+
+func sumBytes(r *api.RecommendRequest) int {
+	if r.Context == nil {
+		return 0
+	}
+	t := 0
+	for _, s := range r.Context.Snippets {
+		t += s.Bytes
+	}
+	return t
+}
+func contains(a []string, x string) bool {
+	for _, v := range a {
+		if v == x {
+			return true
+		}
+	}
+	return false
+}
+func has(a []string, x string) bool { return contains(a, x) }


### PR DESCRIPTION
## Summary
- add request/response types with validation for recommendation API
- load model catalog and score candidates to select best model
- expose `/v1/recommend` with chi and document via OpenAPI

## Testing
- `go build ./...`
- `go test ./...`
- `curl -s -H "X-API-Key: dev" -H "Content-Type: application/json" -d '{"prompt":"hello","context":{"language":"go"}}' http://localhost:8080/v1/recommend | jq`


------
https://chatgpt.com/codex/tasks/task_e_689af0ab9624832fb6f3449d0358b118