### PR TITLE
feat: expose top model recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This service recommends suitable language models for a given prompt and context.
 ## Copilot Extension Integration
 
 - Endpoint: `POST /v1/recommend`
+- Endpoint: `POST /v1/recommend/top` (returns top 3 models)
 - OpenAPI: `api/openapi.yaml`
 - Auth: header `X-API-Key` (set `ROUTER_API_KEY`)
 - **Note:** Calls made from Copilot Chat consume a Copilot request (billing by GitHub).

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -24,6 +24,25 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RecommendResponse'
+  /v1/recommend/top:
+    post:
+      summary: Return top 3 models for a given prompt/context
+      operationId: recommendTop
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RecommendRequest'
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecommendTopResponse'
 components:
   securitySchemes:
     ApiKeyAuth:
@@ -93,3 +112,26 @@ components:
           items: { type: string }
         trace_id: { type: string }
         version: { type: string }
+    RecommendTopResponse:
+      type: object
+      required: [models, version]
+      properties:
+        models:
+          type: array
+          items:
+            $ref: '#/components/schemas/ModelInfo'
+        version: { type: string }
+    ModelInfo:
+      type: object
+      required: [name]
+      properties:
+        name: { type: string }
+        strengths:
+          type: array
+          items: { type: string }
+        max_input_tokens: { type: integer }
+        cost_tier: { type: string }
+        latency_tier: { type: string }
+        languages:
+          type: array
+          items: { type: string }

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -29,6 +29,7 @@ func main() {
 
 	deps := handlers.RecommendDeps{Version: version, Catalog: catalog, APIKey: apiKey}
 	r.Post("/v1/recommend", handlers.Recommend(deps))
+	r.Post("/v1/recommend/top", handlers.RecommendTop(deps))
 
 	addr := ":8080"
 	log.Printf("router listening on %s", addr)

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -48,3 +48,17 @@ type RecommendResponse struct {
 	TraceID           string   `json:"trace_id,omitempty"`
 	Version           string   `json:"version"`
 }
+
+type ModelInfo struct {
+	Name           string   `json:"name"`
+	Strengths      []string `json:"strengths,omitempty"`
+	MaxInputTokens int      `json:"max_input_tokens,omitempty"`
+	CostTier       string   `json:"cost_tier,omitempty"`
+	LatencyTier    string   `json:"latency_tier,omitempty"`
+	Languages      []string `json:"languages,omitempty"`
+}
+
+type RecommendTopResponse struct {
+	Models  []ModelInfo `json:"models"`
+	Version string      `json:"version"`
+}

--- a/internal/http/handlers/recommend_top.go
+++ b/internal/http/handlers/recommend_top.go
@@ -1,0 +1,43 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"llm-router-go/internal/api"
+	"llm-router-go/internal/policy"
+)
+
+// RecommendTop returns up to the top three models for the given request.
+func RecommendTop(d RecommendDeps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if d.APIKey != "" && r.Header.Get("X-API-Key") != d.APIKey {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		var req api.RecommendRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "bad json: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		if err := req.Validate(); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		models := policy.TopModels(d.Catalog, &req, 3)
+		infos := make([]api.ModelInfo, len(models))
+		for i, m := range models {
+			infos[i] = api.ModelInfo{
+				Name:           m.Name,
+				Strengths:      m.Strengths,
+				MaxInputTokens: m.MaxInputTokens,
+				CostTier:       m.CostTier,
+				LatencyTier:    m.LatencyTier,
+				Languages:      m.Languages,
+			}
+		}
+		res := api.RecommendTopResponse{Models: infos, Version: d.Version}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(res)
+	}
+}

--- a/internal/http/handlers/recommend_top_test.go
+++ b/internal/http/handlers/recommend_top_test.go
@@ -1,0 +1,41 @@
+package handlers_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"llm-router-go/internal/api"
+	"llm-router-go/internal/http/handlers"
+	"llm-router-go/internal/policy"
+)
+
+func TestRecommendTop_OK(t *testing.T) {
+	cat := policy.Catalog{Models: []policy.Model{{Name: "gpt-4o-mini"}, {Name: "gpt-4o"}, {Name: "claude-3.5-sonnet"}, {Name: "gemini-1.5-pro"}}}
+	h := handlers.RecommendTop(handlers.RecommendDeps{Version: "test", Catalog: cat})
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	body := []byte(`{"prompt":"explain","context":{"language":"go","selection_bytes":1024}}`)
+	req, _ := http.NewRequest("POST", srv.URL, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.StatusCode != 200 {
+		t.Fatalf("status=%d", res.StatusCode)
+	}
+	var resp api.RecommendTopResponse
+	if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Models) != 3 {
+		t.Fatalf("expected 3 models, got %d", len(resp.Models))
+	}
+	if resp.Models[0].Name != "gpt-4o-mini" {
+		t.Fatalf("unexpected first model: %s", resp.Models[0].Name)
+	}
+}


### PR DESCRIPTION
## Summary
- add /v1/recommend/top endpoint to return top 3 models
- rank catalog models and expose model info in API
- document endpoint and update OpenAPI

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689b95faa064832fb3b17638389560e6