### PR TITLE
Add API middleware, ranking endpoint, and OpenAPI spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This service recommends suitable language models for a given prompt and context.
 ## Copilot Extension Integration
 
 - Endpoint: `POST /v1/recommend`
+- Endpoint: `POST /v1/recommend/top` (returns top 3 models)
 - OpenAPI: `api/openapi.yaml`
 - Auth: header `X-API-Key` (set `ROUTER_API_KEY`)
 - **Note:** Calls made from Copilot Chat consume a Copilot request (billing by GitHub).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# llm-router-go
+
+This service recommends suitable language models for a given prompt and context.
+
+## Copilot Extension Integration
+
+- Endpoint: `POST /v1/recommend`
+- OpenAPI: `api/openapi.yaml`
+- Auth: header `X-API-Key` (set `ROUTER_API_KEY`)
+- **Note:** Calls made from Copilot Chat consume a Copilot request (billing by GitHub).
+- No public API to auto-switch Copilot’s model; we return the recommendation for the client UI to guide the user.
+

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -24,6 +24,25 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RecommendResponse'
+  /v1/recommend/top:
+    post:
+      summary: Return top 3 models for a given prompt/context
+      operationId: recommendTop
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RecommendRequest'
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecommendTopResponse'
 components:
   securitySchemes:
     ApiKeyAuth:
@@ -93,3 +112,26 @@ components:
           items: { type: string }
         trace_id: { type: string }
         version: { type: string }
+    RecommendTopResponse:
+      type: object
+      required: [models, version]
+      properties:
+        models:
+          type: array
+          items:
+            $ref: '#/components/schemas/ModelInfo'
+        version: { type: string }
+    ModelInfo:
+      type: object
+      required: [name]
+      properties:
+        name: { type: string }
+        strengths:
+          type: array
+          items: { type: string }
+        max_input_tokens: { type: integer }
+        cost_tier: { type: string }
+        latency_tier: { type: string }
+        languages:
+          type: array
+          items: { type: string }

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,0 +1,95 @@
+openapi: 3.0.1
+info:
+  title: llm-router
+  version: 1.0.0
+servers:
+  - url: https://YOUR_HOST
+paths:
+  /v1/recommend:
+    post:
+      summary: Recommend the best model for a given prompt/context
+      operationId: recommend
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RecommendRequest'
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecommendResponse'
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key
+  schemas:
+    RecommendRequest:
+      type: object
+      required: [prompt]
+      properties:
+        prompt: { type: string }
+        context:
+          $ref: '#/components/schemas/Context'
+        catalog:
+          type: array
+          items: { type: string }
+        limits:
+          type: object
+          properties:
+            max_prompt_kb: { type: integer }
+        meta:
+          type: object
+          additionalProperties: true
+    Context:
+      type: object
+      properties:
+        language: { type: string }
+        file_path: { type: string }
+        selection_bytes: { type: integer }
+        repo:
+          type: object
+          properties:
+            name: { type: string }
+            visibility: { type: string, enum: [public, private] }
+            monorepo: { type: boolean }
+            loc_estimate: { type: integer }
+        signals:
+          type: object
+          additionalProperties: { type: string }
+        snippets:
+          type: array
+          items:
+            type: object
+            required: [source]
+            properties:
+              source: { type: string, enum: [selection,file,open_editors,clipboard,repo] }
+              path: { type: string }
+              text: { type: string }
+              truncated: { type: boolean }
+              bytes: { type: integer }
+    RecommendResponse:
+      type: object
+      required: [recommended_model, version]
+      properties:
+        recommended_model: { type: string }
+        rationale: { type: string }
+        confidence: { type: number }
+        alternatives:
+          type: array
+          items: { type: string }
+        cost_ms_estimate: { type: integer }
+        tokens_in_estimate: { type: integer }
+        tokens_out_estimate: { type: integer }
+        flags:
+          type: array
+          items: { type: string }
+        trace_id: { type: string }
+        version: { type: string }

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -29,6 +29,7 @@ func main() {
 
 	deps := handlers.RecommendDeps{Version: version, Catalog: catalog, APIKey: apiKey}
 	r.Post("/v1/recommend", handlers.Recommend(deps))
+	r.Post("/v1/recommend/top", handlers.RecommendTop(deps))
 
 	addr := ":8080"
 	log.Printf("router listening on %s", addr)

--- a/config/models.yaml
+++ b/config/models.yaml
@@ -1,48 +1,25 @@
 models:
-  - id: gpt-3.5-turbo
-    name: GPT-3.5 Turbo
-    capabilities:
-      code: 0.65
-      text: 0.80
-      analysis: 0.70
-    cost_input: 0.0005
-    cost_output: 0.0005
-    context_window: 4096
-    latency_ms: 300
-    tags: [budget, general]
-
-  - id: gpt-4-turbo
-    name: GPT-4 Turbo
-    capabilities:
-      code: 0.90
-      text: 0.92
-      analysis: 0.85
-    cost_input: 0.003
-    cost_output: 0.006
-    context_window: 128000
-    latency_ms: 600
-    tags: [premium, high-quality, large-context]
-
-  - id: claude-3-opus
-    name: Claude 3 Opus
-    capabilities:
-      code: 0.88
-      text: 0.93
-      analysis: 0.87
-    cost_input: 0.008
-    cost_output: 0.024
-    context_window: 200000
-    latency_ms: 800
-    tags: [premium, high-quality]
-
-  - id: codellama-70b
-    name: Code Llama 70B (local)
-    capabilities:
-      code: 0.70
-      text: 0.50
-      analysis: 0.40
-    cost_input: 0.0001
-    cost_output: 0.0001
-    context_window: 4096
-    latency_ms: 150
-    tags: [open-source, budget, code]
+  - name: gpt-4o
+    strengths: [reasoning, code-gen]
+    max_input_tokens: 128000
+    cost_tier: high
+    latency_tier: med
+    languages: [ts, js, py, go, java, cpp, md]
+  - name: gpt-4o-mini
+    strengths: [code-gen, fast]
+    max_input_tokens: 64000
+    cost_tier: med
+    latency_tier: low
+    languages: [ts, js, py, go, md]
+  - name: claude-3.5-sonnet
+    strengths: [reasoning, long-context]
+    max_input_tokens: 200000
+    cost_tier: high
+    latency_tier: med
+    languages: [py, ts, go, java, md]
+  - name: gemini-1.5-pro
+    strengths: [multimodal, long-context]
+    max_input_tokens: 1000000
+    cost_tier: high
+    latency_tier: med
+    languages: [md, py, js, go]

--- a/examples/copilot.http
+++ b/examples/copilot.http
@@ -1,0 +1,16 @@
+### Recommend (minimal)
+POST http://localhost:8080/v1/recommend
+Content-Type: application/json
+X-API-Key: dev
+
+{
+  "prompt": "Summarize this function and suggest a model",
+  "context": {
+    "language": "go",
+    "file_path": "internal/http/handlers/recommend.go",
+    "selection_bytes": 2048,
+    "snippets": [
+      {"source":"selection","text":"func foo() {}", "bytes": 14}
+    ]
+  }
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/go-chi/chi/v5 v5.0.8
 	github.com/prometheus/client_golang v1.17.0
+	github.com/sashabaranov/go-openai v1.15.4
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/go-chi/chi/v5 v5.0.8
+	github.com/go-chi/httprate v0.11.0
 	github.com/prometheus/client_golang v1.17.0
 	github.com/sashabaranov/go-openai v1.15.4
 	gopkg.in/yaml.v3 v3.0.1
@@ -12,7 +13,7 @@ require (
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/prometheus/common v0.44.0/go.mod h1:ofAIvZbQ1e/nugmZGz4/qCb9Ap1VoSTIO
 github.com/prometheus/procfs v0.11.1 h1:xRC8Iq1yyca5ypa9n1EZnWZkt7dwcoRPQwX/5gwaUuI=
 github.com/prometheus/procfs v0.11.1/go.mod h1:eesXgaPo1q7lBpVMoMy0ZOFTth9hBn4W/y0/p/ScXhY=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
+github.com/sashabaranov/go-openai v1.15.4 h1:BXCR0Uxk5RipeY4yBC7g6pBVfcjh8jwrMNOYdie6yuk=
+github.com/sashabaranov/go-openai v1.15.4/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.11.0 h1:eG7RXZHdqOJ1i+0lgLgCpSXAp6M3LYlAo6osgSi0xOM=
 golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/go.sum
+++ b/go.sum
@@ -1,13 +1,15 @@
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
-github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
+github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/go-chi/chi/v5 v5.0.8 h1:lD+NLqFcAi1ovnVZpsnObHGW4xb4J8lNmoYVfECH1Y0=
 github.com/go-chi/chi/v5 v5.0.8/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
+github.com/go-chi/httprate v0.11.0 h1:GKsQF0qlVSU1Zg/D07tUUnNrYTTkrtpMihwO6myxtzc=
+github.com/go-chi/httprate v0.11.0/go.mod h1:TUepLXaz/pCjmCtf/obgOQJ2Sz6rC8fSf5cAt5cnTt0=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
@@ -31,6 +33,7 @@ github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjR
 github.com/sashabaranov/go-openai v1.15.4 h1:BXCR0Uxk5RipeY4yBC7g6pBVfcjh8jwrMNOYdie6yuk=
 github.com/sashabaranov/go-openai v1.15.4/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
 golang.org/x/sys v0.11.0 h1:eG7RXZHdqOJ1i+0lgLgCpSXAp6M3LYlAo6osgSi0xOM=
 golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -48,3 +48,17 @@ type RecommendResponse struct {
 	TraceID           string   `json:"trace_id,omitempty"`
 	Version           string   `json:"version"`
 }
+
+type ModelInfo struct {
+	Name           string   `json:"name"`
+	Strengths      []string `json:"strengths,omitempty"`
+	MaxInputTokens int      `json:"max_input_tokens,omitempty"`
+	CostTier       string   `json:"cost_tier,omitempty"`
+	LatencyTier    string   `json:"latency_tier,omitempty"`
+	Languages      []string `json:"languages,omitempty"`
+}
+
+type RecommendTopResponse struct {
+	Models  []ModelInfo `json:"models"`
+	Version string      `json:"version"`
+}

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -1,0 +1,50 @@
+package api
+
+type RecommendRequest struct {
+	Prompt  string         `json:"prompt"`
+	Context *Context       `json:"context,omitempty"`
+	Catalog []string       `json:"catalog,omitempty"`
+	Limits  *Limits        `json:"limits,omitempty"`
+	Meta    map[string]any `json:"meta,omitempty"`
+}
+
+type Context struct {
+	Language       string            `json:"language,omitempty"`
+	FilePath       string            `json:"file_path,omitempty"`
+	SelectionBytes int               `json:"selection_bytes,omitempty"`
+	Repo           *RepoInfo         `json:"repo,omitempty"`
+	Signals        map[string]string `json:"signals,omitempty"`
+	Snippets       []ContextSnippet  `json:"snippets,omitempty"`
+}
+
+type ContextSnippet struct {
+	Source    string `json:"source"`
+	Path      string `json:"path,omitempty"`
+	Text      string `json:"text,omitempty"`
+	Truncated bool   `json:"truncated,omitempty"`
+	Bytes     int    `json:"bytes,omitempty"`
+}
+
+type RepoInfo struct {
+	Name        string `json:"name,omitempty"`
+	Visibility  string `json:"visibility,omitempty"`
+	Monorepo    bool   `json:"monorepo,omitempty"`
+	LocEstimate int    `json:"loc_estimate,omitempty"`
+}
+
+type Limits struct {
+	MaxPromptKB int `json:"max_prompt_kb,omitempty"`
+}
+
+type RecommendResponse struct {
+	RecommendedModel  string   `json:"recommended_model"`
+	Rationale         string   `json:"rationale,omitempty"`
+	Confidence        float32  `json:"confidence,omitempty"`
+	Alternatives      []string `json:"alternatives,omitempty"`
+	CostMsEstimate    int      `json:"cost_ms_estimate,omitempty"`
+	TokensInEstimate  int      `json:"tokens_in_estimate,omitempty"`
+	TokensOutEstimate int      `json:"tokens_out_estimate,omitempty"`
+	Flags             []string `json:"flags,omitempty"`
+	TraceID           string   `json:"trace_id,omitempty"`
+	Version           string   `json:"version"`
+}

--- a/internal/api/validate.go
+++ b/internal/api/validate.go
@@ -1,0 +1,13 @@
+package api
+
+import "errors"
+
+func (r *RecommendRequest) Validate() error {
+	if r.Prompt == "" {
+		return errors.New("prompt is required")
+	}
+	if r.Limits != nil && r.Limits.MaxPromptKB < 0 {
+		return errors.New("limits.max_prompt_kb must be >= 0")
+	}
+	return nil
+}

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -1,0 +1,71 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"llm-router-go/internal/config"
+	"llm-router-go/internal/metrics"
+	"llm-router-go/internal/selection"
+)
+
+type Handler struct{ cfg *config.ConfigStore }
+
+func New(cfg *config.ConfigStore) *Handler { return &Handler{cfg: cfg} }
+
+func (h *Handler) Health(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ok"))
+}
+
+func (h *Handler) Models(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(h.cfg.GetModels())
+}
+
+func (h *Handler) Metrics() http.Handler { return promhttp.Handler() }
+
+func (h *Handler) SelectModel(w http.ResponseWriter, r *http.Request) {
+	start := time.Now()
+	defer func() { metrics.SelectionLatency.Observe(float64(time.Since(start).Milliseconds())) }()
+
+	var req selection.SelectRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		metrics.RequestsTotal.WithLabelValues("select", "400").Inc()
+		http.Error(w, "invalid JSON payload: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	resp, err := selection.Selector(h.cfg, req)
+	if err != nil {
+		metrics.RequestsTotal.WithLabelValues("select", "422").Inc()
+		http.Error(w, err.Error(), http.StatusUnprocessableEntity)
+		return
+	}
+	metrics.RequestsTotal.WithLabelValues("select", "200").Inc()
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func (h *Handler) RankModels(w http.ResponseWriter, r *http.Request) {
+	start := time.Now()
+	defer func() { metrics.SelectionLatency.Observe(float64(time.Since(start).Milliseconds())) }()
+
+	var req selection.SelectRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		metrics.RequestsTotal.WithLabelValues("rank", "400").Inc()
+		http.Error(w, "invalid JSON payload: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	resp, err := selection.Ranker(h.cfg, req)
+	if err != nil {
+		metrics.RequestsTotal.WithLabelValues("rank", "422").Inc()
+		http.Error(w, err.Error(), http.StatusUnprocessableEntity)
+		return
+	}
+	metrics.RequestsTotal.WithLabelValues("rank", "200").Inc()
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}

--- a/internal/http/handlers/recommend.go
+++ b/internal/http/handlers/recommend.go
@@ -1,0 +1,47 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"llm-router-go/internal/api"
+	"llm-router-go/internal/policy"
+)
+
+type RecommendDeps struct {
+	Version string
+	Catalog policy.Catalog
+	APIKey  string
+}
+
+func Recommend(d RecommendDeps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		if d.APIKey != "" && r.Header.Get("X-API-Key") != d.APIKey {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		var req api.RecommendRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "bad json: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		if err := req.Validate(); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		dec := policy.Score(d.Catalog, &req)
+		res := api.RecommendResponse{
+			RecommendedModel: dec.Top,
+			Rationale:        dec.Rationale,
+			Confidence:       dec.Confidence,
+			Alternatives:     dec.Alternatives,
+			CostMsEstimate:   int(time.Since(start).Milliseconds()),
+			Flags:            dec.Flags,
+			Version:          d.Version,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(res)
+	}
+}

--- a/internal/http/handlers/recommend_test.go
+++ b/internal/http/handlers/recommend_test.go
@@ -1,0 +1,42 @@
+package handlers_test
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"llm-router-go/internal/http/handlers"
+	"llm-router-go/internal/policy"
+)
+
+func TestRecommend_OK(t *testing.T) {
+	cat := policy.Catalog{Models: []policy.Model{{Name: "gpt-4o"}, {Name: "gpt-4o-mini"}}}
+	h := handlers.Recommend(handlers.RecommendDeps{Version: "test", Catalog: cat})
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	body := []byte(`{"prompt":"explain this","context":{"language":"go","selection_bytes":1024}}`)
+	req, _ := http.NewRequest("POST", srv.URL, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.StatusCode != 200 {
+		t.Fatalf("status=%d", res.StatusCode)
+	}
+}
+
+func TestRecommend_Auth(t *testing.T) {
+	cat := policy.Catalog{Models: []policy.Model{{Name: "gpt-4o"}}}
+	h := handlers.Recommend(handlers.RecommendDeps{Version: "test", Catalog: cat, APIKey: "dev"})
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	req, _ := http.NewRequest("POST", srv.URL, bytes.NewReader([]byte(`{"prompt":"x"}`)))
+	req.Header.Set("Content-Type", "application/json")
+	if res, _ := http.DefaultClient.Do(req); res.StatusCode != 401 {
+		t.Fatalf("expected 401, got %d", res.StatusCode)
+	}
+}

--- a/internal/http/handlers/recommend_top.go
+++ b/internal/http/handlers/recommend_top.go
@@ -1,0 +1,43 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"llm-router-go/internal/api"
+	"llm-router-go/internal/policy"
+)
+
+// RecommendTop returns up to the top three models for the given request.
+func RecommendTop(d RecommendDeps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if d.APIKey != "" && r.Header.Get("X-API-Key") != d.APIKey {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		var req api.RecommendRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "bad json: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		if err := req.Validate(); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		models := policy.TopModels(d.Catalog, &req, 3)
+		infos := make([]api.ModelInfo, len(models))
+		for i, m := range models {
+			infos[i] = api.ModelInfo{
+				Name:           m.Name,
+				Strengths:      m.Strengths,
+				MaxInputTokens: m.MaxInputTokens,
+				CostTier:       m.CostTier,
+				LatencyTier:    m.LatencyTier,
+				Languages:      m.Languages,
+			}
+		}
+		res := api.RecommendTopResponse{Models: infos, Version: d.Version}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(res)
+	}
+}

--- a/internal/http/handlers/recommend_top_test.go
+++ b/internal/http/handlers/recommend_top_test.go
@@ -1,0 +1,41 @@
+package handlers_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"llm-router-go/internal/api"
+	"llm-router-go/internal/http/handlers"
+	"llm-router-go/internal/policy"
+)
+
+func TestRecommendTop_OK(t *testing.T) {
+	cat := policy.Catalog{Models: []policy.Model{{Name: "gpt-4o-mini"}, {Name: "gpt-4o"}, {Name: "claude-3.5-sonnet"}, {Name: "gemini-1.5-pro"}}}
+	h := handlers.RecommendTop(handlers.RecommendDeps{Version: "test", Catalog: cat})
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	body := []byte(`{"prompt":"explain","context":{"language":"go","selection_bytes":1024}}`)
+	req, _ := http.NewRequest("POST", srv.URL, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.StatusCode != 200 {
+		t.Fatalf("status=%d", res.StatusCode)
+	}
+	var resp api.RecommendTopResponse
+	if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Models) != 3 {
+		t.Fatalf("expected 3 models, got %d", len(resp.Models))
+	}
+	if resp.Models[0].Name != "gpt-4o-mini" {
+		t.Fatalf("unexpected first model: %s", resp.Models[0].Name)
+	}
+}

--- a/internal/inference/inference.go
+++ b/internal/inference/inference.go
@@ -1,0 +1,43 @@
+package inference
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+
+	openai "github.com/sashabaranov/go-openai"
+)
+
+// SendPrompt sends the given prompt to the specified model and returns the model's
+// response. Currently only OpenAI GPT models are supported. The OpenAI API key
+// must be provided via the OPENAI_API_KEY environment variable.
+func SendPrompt(modelID, prompt string) (string, error) {
+	if strings.HasPrefix(modelID, "gpt-") {
+		apiKey := os.Getenv("OPENAI_API_KEY")
+		if apiKey == "" {
+			return "", errors.New("OPENAI_API_KEY not set")
+		}
+		client := openai.NewClient(apiKey)
+		resp, err := client.CreateChatCompletion(
+			context.Background(),
+			openai.ChatCompletionRequest{
+				Model: modelID,
+				Messages: []openai.ChatCompletionMessage{
+					{
+						Role:    openai.ChatMessageRoleUser,
+						Content: prompt,
+					},
+				},
+			},
+		)
+		if err != nil {
+			return "", err
+		}
+		if len(resp.Choices) == 0 {
+			return "", errors.New("empty response from model")
+		}
+		return resp.Choices[0].Message.Content, nil
+	}
+	return "", errors.New("unsupported model: " + modelID)
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,24 @@
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var (
+	RequestsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "router_requests_total",
+			Help: "Total number of requests by endpoint and status",
+		},
+		[]string{"endpoint", "status"},
+	)
+	SelectionLatency = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "router_selection_latency_ms",
+			Help:    "Latency of selection requests in ms",
+			Buckets: prometheus.ExponentialBuckets(10, 2, 8),
+		},
+	)
+)
+
+func MustRegister() {
+	prometheus.MustRegister(RequestsTotal, SelectionLatency)
+}

--- a/internal/policy/catalog.go
+++ b/internal/policy/catalog.go
@@ -1,0 +1,28 @@
+package policy
+
+import (
+	"gopkg.in/yaml.v3"
+	"os"
+)
+
+type Model struct {
+	Name           string   `yaml:"name"`
+	Strengths      []string `yaml:"strengths"`
+	MaxInputTokens int      `yaml:"max_input_tokens"`
+	CostTier       string   `yaml:"cost_tier"`
+	LatencyTier    string   `yaml:"latency_tier"`
+	Languages      []string `yaml:"languages"`
+}
+
+type Catalog struct {
+	Models []Model `yaml:"models"`
+}
+
+func LoadCatalog(path string) (Catalog, error) {
+	var c Catalog
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return c, err
+	}
+	return c, yaml.Unmarshal(b, &c)
+}

--- a/internal/policy/score.go
+++ b/internal/policy/score.go
@@ -1,0 +1,98 @@
+package policy
+
+import (
+	"llm-router-go/internal/api"
+	"strings"
+)
+
+type Decision struct {
+	Top          string
+	Alternatives []string
+	Confidence   float32
+	Rationale    string
+	Flags        []string
+}
+
+func Score(c Catalog, req *api.RecommendRequest) Decision {
+	long := req.Context != nil && (req.Context.SelectionBytes > 48000 || sumBytes(req) > 120000)
+	lang := ""
+	if req.Context != nil {
+		lang = req.Context.Language
+	}
+
+	limit := map[string]bool{}
+	if len(req.Catalog) > 0 {
+		for _, m := range req.Catalog {
+			limit[m] = true
+		}
+	}
+
+	cands := []string{}
+	for _, m := range c.Models {
+		if len(limit) > 0 && !limit[m.Name] {
+			continue
+		}
+		if lang != "" && !contains(m.Languages, lang) {
+			continue
+		}
+		cands = append(cands, m.Name)
+	}
+	if len(cands) == 0 {
+		for _, m := range c.Models {
+			cands = append(cands, m.Name)
+		}
+	}
+
+	var top string
+	var conf float32 = 0.6
+	var why []string
+	flags := []string{}
+
+	if long {
+		for _, n := range []string{"claude-3.5-sonnet", "gemini-1.5-pro", "gpt-4o"} {
+			if has(cands, n) {
+				top = n
+				break
+			}
+		}
+		why = append(why, "Detected large context; prefer long-context models.")
+		flags = append(flags, "large_context")
+		conf = 0.72
+	} else {
+		for _, n := range []string{"gpt-4o-mini", "gpt-4o", "claude-3.5-sonnet"} {
+			if has(cands, n) {
+				top = n
+				break
+			}
+		}
+		why = append(why, "Moderate prompt; prefer fast code-generation.")
+	}
+
+	alts := []string{}
+	for _, n := range cands {
+		if n != top {
+			alts = append(alts, n)
+		}
+	}
+	return Decision{Top: top, Alternatives: alts, Confidence: conf, Rationale: strings.Join(why, " "), Flags: flags}
+}
+
+func sumBytes(r *api.RecommendRequest) int {
+	if r.Context == nil {
+		return 0
+	}
+	t := 0
+	for _, s := range r.Context.Snippets {
+		t += s.Bytes
+	}
+	return t
+}
+func contains(a []string, x string) bool {
+	for _, v := range a {
+		if v == x {
+			return true
+		}
+	}
+	return false
+}
+func has(a []string, x string) bool { return contains(a, x) }

--- a/internal/selection/api.go
+++ b/internal/selection/api.go
@@ -1,0 +1,163 @@
+package selection
+
+import (
+	"errors"
+	"math"
+	"sort"
+
+	"llm-router-go/internal/classifier"
+	"llm-router-go/internal/config"
+	"llm-router-go/internal/policy"
+	"llm-router-go/internal/scoring"
+	"llm-router-go/internal/types"
+)
+
+type Preferences struct {
+	Prioritize      string `json:"prioritize,omitempty"`
+	AllowTruncation bool   `json:"allow_truncation,omitempty"`
+}
+
+type SelectRequest struct {
+	Prompt      string         `json:"prompt"`
+	Context     *types.Context `json:"context,omitempty"`
+	Preferences *Preferences   `json:"preferences,omitempty"`
+	Candidates  []string       `json:"candidates,omitempty"`
+	TopK        int            `json:"top_k,omitempty"`
+}
+
+type RankedModel struct {
+	ModelID               string   `json:"model_id"`
+	Name                  string   `json:"name"`
+	Score                 float64  `json:"score"`
+	Percent               float64  `json:"percent"`
+	Quality               float64  `json:"quality"`
+	SuccessProb           float64  `json:"success_prob"`
+	EstimatedCost         float64  `json:"estimated_cost"`
+	ExpectedLatencyMs     int      `json:"expected_latency_ms"`
+	Reasons               []string `json:"reasons"`
+	EstimatedOutputTokens int      `json:"-"`
+}
+
+type RankResponse struct {
+	PromptType            string             `json:"prompt_type"`
+	ComplexityScore       float64            `json:"complexity_score"`
+	SubScores             map[string]float64 `json:"sub_scores"`
+	TokensIn              int                `json:"tokens_in"`
+	EstimatedOutputTokens int                `json:"estimated_output_tokens"`
+	Models                []RankedModel      `json:"models"`
+}
+
+func Selector(cfg *config.ConfigStore, req SelectRequest) (Result, error) {
+	prefs := map[string]interface{}{}
+	if req.Preferences != nil {
+		if req.Preferences.Prioritize != "" {
+			prefs["prioritize"] = req.Preferences.Prioritize
+		}
+		if req.Preferences.AllowTruncation {
+			prefs["allow_truncation"] = req.Preferences.AllowTruncation
+		}
+	}
+	models := cfg.GetModels()
+	if len(req.Candidates) > 0 {
+		cand := map[string]bool{}
+		for _, c := range req.Candidates {
+			cand[c] = true
+		}
+		filtered := make([]config.Model, 0, len(models))
+		for _, m := range models {
+			if cand[m.ID] {
+				filtered = append(filtered, m)
+			}
+		}
+		models = filtered
+	}
+	return SelectModel(req.Prompt, req.Context, models, prefs)
+}
+
+func Ranker(cfg *config.ConfigStore, req SelectRequest) (RankResponse, error) {
+	prefs := map[string]interface{}{}
+	prioritise := "quality"
+	allowTrunc := false
+	if req.Preferences != nil {
+		if req.Preferences.Prioritize != "" {
+			prioritise = req.Preferences.Prioritize
+			prefs["prioritize"] = req.Preferences.Prioritize
+		}
+		if req.Preferences.AllowTruncation {
+			allowTrunc = true
+			prefs["allow_truncation"] = true
+		}
+	}
+	models := cfg.GetModels()
+	if len(req.Candidates) > 0 {
+		cand := map[string]bool{}
+		for _, c := range req.Candidates {
+			cand[c] = true
+		}
+		filtered := make([]config.Model, 0, len(models))
+		for _, m := range models {
+			if cand[m.ID] {
+				filtered = append(filtered, m)
+			}
+		}
+		models = filtered
+	}
+	if len(models) == 0 {
+		return RankResponse{}, errors.New("no models available")
+	}
+	weights := policy.DetermineWeights(prioritise)
+	pt := classifier.Classify(req.Prompt, req.Context)
+	complexity, subScores := scoring.ComputeComplexity(req.Prompt, req.Context)
+	tokensIn := len(scoring.Tokenize(req.Prompt))
+	if req.Context != nil {
+		for _, f := range req.Context.Files {
+			tokensIn += len(scoring.Tokenize(f.Content))
+		}
+	}
+	ranked := make([]RankedModel, 0, len(models))
+	for i := range models {
+		m := &models[i]
+		if !allowTrunc && tokensIn > m.ContextWindow {
+			continue
+		}
+		util, quality, successProb, cost, _, estOut := policy.ComputeUtility(*m, pt, tokensIn, complexity, weights)
+		ranked = append(ranked, RankedModel{
+			ModelID:               m.ID,
+			Name:                  m.Name,
+			Score:                 util,
+			Quality:               quality,
+			SuccessProb:           successProb,
+			EstimatedCost:         cost,
+			ExpectedLatencyMs:     m.LatencyMs,
+			Reasons:               []string{},
+			EstimatedOutputTokens: estOut,
+		})
+	}
+	if len(ranked) == 0 {
+		return RankResponse{}, errors.New("no suitable model found for given prompt and context")
+	}
+	sumExp := 0.0
+	for _, rm := range ranked {
+		sumExp += math.Exp(rm.Score)
+	}
+	for i := range ranked {
+		ranked[i].Percent = math.Exp(ranked[i].Score) / sumExp * 100
+	}
+	sort.Slice(ranked, func(i, j int) bool { return ranked[i].Percent > ranked[j].Percent })
+	topK := req.TopK
+	if topK <= 0 {
+		topK = 5
+	}
+	if topK < len(ranked) {
+		ranked = ranked[:topK]
+	}
+	resp := RankResponse{
+		PromptType:            pt,
+		ComplexityScore:       math.Round(complexity*1000) / 1000,
+		SubScores:             subScores,
+		TokensIn:              tokensIn,
+		EstimatedOutputTokens: ranked[0].EstimatedOutputTokens,
+		Models:                ranked,
+	}
+	return resp, nil
+}

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -1,0 +1,29 @@
+package server
+
+import (
+	"net/http"
+	"os"
+	"strings"
+)
+
+func APIKeyAuth(next http.Handler) http.Handler {
+	keysCSV := os.Getenv("ROUTER_API_KEYS")
+	keys := map[string]bool{}
+	for _, k := range strings.Split(keysCSV, ",") {
+		k = strings.TrimSpace(k)
+		if k != "" {
+			keys[k] = true
+		}
+	}
+	if len(keys) == 0 {
+		return next
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		key := r.Header.Get("X-API-Key")
+		if key == "" || !keys[key] {
+			http.Error(w, `{"error":"unauthorized","message":"missing or invalid API key"}`, http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/server/cors.go
+++ b/internal/server/cors.go
@@ -1,0 +1,36 @@
+package server
+
+import (
+	"net/http"
+	"strings"
+)
+
+func CORS(allowedOriginsCSV string) func(http.Handler) http.Handler {
+	allowed := map[string]bool{}
+	for _, o := range strings.Split(allowedOriginsCSV, ",") {
+		o = strings.TrimSpace(o)
+		if o != "" {
+			allowed[o] = true
+		}
+	}
+	allowAll := allowed["*"]
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			origin := r.Header.Get("Origin")
+			if origin != "" && (allowAll || allowed[origin]) {
+				w.Header().Set("Vary", "Origin")
+				w.Header().Set("Access-Control-Allow-Origin", origin)
+				w.Header().Set("Access-Control-Allow-Credentials", "true")
+				w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-API-Key")
+				w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+				w.Header().Set("Access-Control-Max-Age", "86400")
+			}
+			if r.Method == http.MethodOptions {
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -1,70 +1,114 @@
 package server
 
 import (
-    "encoding/json"
-    "log"
-    "net/http"
+	"encoding/json"
+	"log"
+	"net/http"
 
-    "llm-router-go/internal/config"
-    "llm-router-go/internal/selection"
-    "llm-router-go/internal/types"
+	"llm-router-go/internal/config"
+	"llm-router-go/internal/inference"
+	"llm-router-go/internal/selection"
+	"llm-router-go/internal/types"
 )
 
 // SelectRequest represents the JSON payload for selecting a model.
 type SelectRequest struct {
-    Prompt      string                 `json:"prompt"`
-    Context     *types.Context         `json:"context"`
-    Preferences map[string]interface{} `json:"preferences"`
+	Prompt      string                 `json:"prompt"`
+	Context     *types.Context         `json:"context"`
+	Preferences map[string]interface{} `json:"preferences"`
 }
 
 // SelectHandler returns an http.HandlerFunc that selects a model using the
 // provided ConfigStore.  The handler reads the JSON payload, invokes the
 // selection logic and writes the response as JSON.
 func SelectHandler(store *config.ConfigStore) http.HandlerFunc {
-    return func(w http.ResponseWriter, r *http.Request) {
-        // Decode request
-        var req SelectRequest
-        dec := json.NewDecoder(r.Body)
-        dec.DisallowUnknownFields()
-        if err := dec.Decode(&req); err != nil {
-            http.Error(w, "invalid JSON payload", http.StatusBadRequest)
-            return
-        }
-        if req.Prompt == "" {
-            http.Error(w, "prompt is required", http.StatusBadRequest)
-            return
-        }
-        models := store.GetModels()
-        result, err := selection.SelectModel(req.Prompt, req.Context, models, req.Preferences)
-        if err != nil {
-            http.Error(w, err.Error(), http.StatusBadRequest)
-            return
-        }
-        w.Header().Set("Content-Type", "application/json")
-        enc := json.NewEncoder(w)
-        enc.SetIndent("", "  ")
-        if err := enc.Encode(result); err != nil {
-            log.Printf("failed to write response: %v", err)
-        }
-    }
+	return func(w http.ResponseWriter, r *http.Request) {
+		// Decode request
+		var req SelectRequest
+		dec := json.NewDecoder(r.Body)
+		dec.DisallowUnknownFields()
+		if err := dec.Decode(&req); err != nil {
+			http.Error(w, "invalid JSON payload", http.StatusBadRequest)
+			return
+		}
+		if req.Prompt == "" {
+			http.Error(w, "prompt is required", http.StatusBadRequest)
+			return
+		}
+		models := store.GetModels()
+		result, err := selection.SelectModel(req.Prompt, req.Context, models, req.Preferences)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(result); err != nil {
+			log.Printf("failed to write response: %v", err)
+		}
+	}
+}
+
+// GenerateResponse contains both the selected model details and the model's
+// output text.
+type GenerateResponse struct {
+	Model  selection.Result `json:"model"`
+	Output string           `json:"output"`
+}
+
+// GenerateHandler selects the best model for the given prompt and then forwards
+// the prompt to that model, returning the model's output.
+func GenerateHandler(store *config.ConfigStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req SelectRequest
+		dec := json.NewDecoder(r.Body)
+		dec.DisallowUnknownFields()
+		if err := dec.Decode(&req); err != nil {
+			http.Error(w, "invalid JSON payload", http.StatusBadRequest)
+			return
+		}
+		if req.Prompt == "" {
+			http.Error(w, "prompt is required", http.StatusBadRequest)
+			return
+		}
+		models := store.GetModels()
+		result, err := selection.SelectModel(req.Prompt, req.Context, models, req.Preferences)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		output, err := inference.SendPrompt(result.RecommendedModel, req.Prompt)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadGateway)
+			return
+		}
+		resp := GenerateResponse{Model: result, Output: output}
+		w.Header().Set("Content-Type", "application/json")
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(resp); err != nil {
+			log.Printf("failed to write response: %v", err)
+		}
+	}
 }
 
 // ModelsHandler writes the current models registry as JSON.
 func ModelsHandler(store *config.ConfigStore) http.HandlerFunc {
-    return func(w http.ResponseWriter, r *http.Request) {
-        models := store.GetModels()
-        w.Header().Set("Content-Type", "application/json")
-        enc := json.NewEncoder(w)
-        enc.SetIndent("", "  ")
-        if err := enc.Encode(models); err != nil {
-            log.Printf("failed to write models response: %v", err)
-        }
-    }
+	return func(w http.ResponseWriter, r *http.Request) {
+		models := store.GetModels()
+		w.Header().Set("Content-Type", "application/json")
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(models); err != nil {
+			log.Printf("failed to write models response: %v", err)
+		}
+	}
 }
 
 // HealthHandler is a simple liveness check.
 func HealthHandler(w http.ResponseWriter, r *http.Request) {
-    w.Header().Set("Content-Type", "text/plain")
-    w.WriteHeader(http.StatusOK)
-    _, _ = w.Write([]byte("ok"))
+	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ok"))
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,25 +1,27 @@
 package server
 
 import (
-    "net/http"
+	"net/http"
 
-    "github.com/go-chi/chi/v5"
-    "github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/go-chi/chi/v5"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 
-    "llm-router-go/internal/config"
+	"llm-router-go/internal/config"
 )
 
 // NewRouter constructs a chi Router with all API routes registered.  It
 // requires a ConfigStore containing the loaded models.
 func NewRouter(store *config.ConfigStore) http.Handler {
-    r := chi.NewRouter()
-    // Health check
-    r.Get("/v1/health", HealthHandler)
-    // Model registry
-    r.Get("/v1/models", ModelsHandler(store))
-    // Selection endpoint
-    r.Post("/v1/select-model", SelectHandler(store))
-    // Prometheus metrics
-    r.Handle("/metrics", promhttp.Handler())
-    return r
+	r := chi.NewRouter()
+	// Health check
+	r.Get("/v1/health", HealthHandler)
+	// Model registry
+	r.Get("/v1/models", ModelsHandler(store))
+	// Selection endpoint
+	r.Post("/v1/select-model", SelectHandler(store))
+	// Generate endpoint - selects a model and forwards the prompt
+	r.Post("/v1/generate", GenerateHandler(store))
+	// Prometheus metrics
+	r.Handle("/metrics", promhttp.Handler())
+	return r
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2,26 +2,53 @@ package server
 
 import (
 	"net/http"
+	"os"
+	"time"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/go-chi/chi/v5/middleware"
+	"github.com/go-chi/httprate"
 
 	"llm-router-go/internal/config"
+	"llm-router-go/internal/handlers"
+	"llm-router-go/internal/metrics"
 )
 
-// NewRouter constructs a chi Router with all API routes registered.  It
-// requires a ConfigStore containing the loaded models.
-func NewRouter(store *config.ConfigStore) http.Handler {
+type Server struct{ h *handlers.Handler }
+
+func New(cfg *config.ConfigStore) *Server {
+	metrics.MustRegister()
+	return &Server{h: handlers.New(cfg)}
+}
+
+func (s *Server) Router() *chi.Mux {
 	r := chi.NewRouter()
-	// Health check
-	r.Get("/v1/health", HealthHandler)
-	// Model registry
-	r.Get("/v1/models", ModelsHandler(store))
-	// Selection endpoint
-	r.Post("/v1/select-model", SelectHandler(store))
-	// Generate endpoint - selects a model and forwards the prompt
-	r.Post("/v1/generate", GenerateHandler(store))
-	// Prometheus metrics
-	r.Handle("/metrics", promhttp.Handler())
+
+	r.Use(middleware.RealIP)
+	r.Use(middleware.RequestID)
+	r.Use(middleware.Logger)
+	r.Use(middleware.Recoverer)
+
+	allowed := os.Getenv("ALLOWED_ORIGINS")
+	if allowed == "" {
+		allowed = "*"
+	}
+	r.Use(CORS(allowed))
+
+	r.Group(func(gr chi.Router) {
+		gr.Use(httprate.LimitByIP(100, 60*time.Second))
+
+		gr.Get("/v1/health", s.h.Health)
+		gr.Get("/v1/models", s.h.Models)
+
+		gr.Group(func(pr chi.Router) {
+			pr.Use(APIKeyAuth)
+			pr.Post("/v1/select-model", s.h.SelectModel)
+			pr.Post("/v1/rank-models", s.h.RankModels)
+		})
+	})
+
+	r.Handle("/metrics", s.h.Metrics())
+	r.NotFound(func(w http.ResponseWriter, r *http.Request) { http.NotFound(w, r) })
 	return r
 }

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1,0 +1,110 @@
+openapi: 3.0.3
+info:
+  title: LLM Router API
+  version: 1.0.0
+servers:
+  - url: https://api.yourdomain.com
+paths:
+  /v1/select-model:
+    post:
+      summary: Select the single best model
+      security: [{ ApiKeyAuth: [] }]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/SelectRequest' }
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/SelectResponse' }
+  /v1/rank-models:
+    post:
+      summary: Rank models and return top-K with percentages
+      security: [{ ApiKeyAuth: [] }]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/SelectRequestWithTopK' }
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/RankResponse' }
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key
+  schemas:
+    File:
+      type: object
+      required: [path, content]
+      properties:
+        path: { type: string }
+        content: { type: string }
+    SelectRequest:
+      type: object
+      required: [prompt]
+      properties:
+        prompt: { type: string }
+        context:
+          type: object
+          properties:
+            language: { type: string }
+            files:
+              type: array
+              items: { $ref: '#/components/schemas/File' }
+        preferences:
+          type: object
+          properties:
+            prioritize:
+              type: string
+              enum: [quality, cost, latency]
+            allow_truncation: { type: boolean }
+        candidates:
+          type: array
+          items: { type: string }
+    SelectRequestWithTopK:
+      allOf:
+        - $ref: '#/components/schemas/SelectRequest'
+        - type: object
+          properties:
+            top_k: { type: integer, minimum: 1, maximum: 20, default: 5 }
+    SelectResponse:
+      type: object
+      properties:
+        recommended_model: { type: string }
+        confidence: { type: number, format: float }
+        model_name: { type: string }
+        explanation: { type: object, additionalProperties: true }
+    RankedModel:
+      type: object
+      properties:
+        model_id: { type: string }
+        name: { type: string }
+        score: { type: number }
+        percent: { type: number }
+        quality: { type: number }
+        success_prob: { type: number }
+        estimated_cost: { type: number }
+        expected_latency_ms: { type: integer }
+        reasons:
+          type: array
+          items: { type: string }
+    RankResponse:
+      type: object
+      properties:
+        prompt_type: { type: string }
+        complexity_score: { type: number }
+        sub_scores: { type: object, additionalProperties: { type: number } }
+        tokens_in: { type: integer }
+        estimated_output_tokens: { type: integer }
+        models:
+          type: array
+          items: { $ref: '#/components/schemas/RankedModel' }


### PR DESCRIPTION
## Summary
- add CORS and API key middleware for the HTTP server
- expose `/v1/select-model` and `/v1/rank-models` handlers with metrics
- publish OpenAPI specification for client generation

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689c2c2f0600832fbeed35d390d72cf4